### PR TITLE
Link to iatistandard.org in the site description

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 ---
 
 <div class="jumbotron">
-  <p class="lead">{{ site.description }}</p>
+  <p class="lead">Tools and guidance contributed by community members, in support of <a href="https://iatistandard.org">IATI</a> infrastructure, publishers and data users.</p>
 </div>
 <hr />
 <div class="container">


### PR DESCRIPTION
Provide a link back to [iatistandard.org](https://iatistandard.org), so that official tools are more easily discoverable.