### PR TITLE
Removing IRC link as afaik we are not available there

### DIFF
--- a/pages/get-involved.md
+++ b/pages/get-involved.md
@@ -7,8 +7,7 @@ excerpt: Learn how to get involved in Code for IATI.
 
 There are many different ways you can get involved.
 
-* Want to chat? Join us on IRC: [https://webchat.freenode.net/#codeforiati](https://webchat.freenode.net/#codeforiati)
-* Want to talk? Join us on [Discord](https://discord.gg/hdH5bEXePM), or on [Twitter](https://twitter.com/search?q=%23iati&f=live))
+* Want to chat? Join us on [Discord](https://discord.gg/hdH5bEXePM), or on [Twitter](https://twitter.com/search?q=%23iati&f=live))
 * Want to suggest improvements or flag issues with tools? [Add them on Github](https://github.com/codeforIATI)
 * Want to suggest a new tool or idea? [See all existing ideas, or create a new issue here](https://github.com/codeforIATI/iati-ideas/issues)
 * Want to to email us? [hello@codeforiati.org](mailto:hello@codeforiati.org)


### PR DESCRIPTION
I don't think we use the IRC so thought best to remove it in case people expect to find us there - or is it a hotbed of activity/useful backup and so should stay?