### PR TITLE
Add privacy policy

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,22 @@
     <meta property="og:type" content="website">
     <meta property="og:description" content="{{ page.excerpt }}">
     <meta property="og:image" content="{{ site.github.url }}/assets/img/logo-square.png?v={{ site.github.build_revision }}">
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["disableCookies"]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//matomo.codeforiati.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
   </head>
   <body class="d-flex flex-column h-100">
     <nav class="navbar navbar-light bg-light navbar-expand-lg header">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,7 +73,8 @@
         <div class="row">
           <div class="col-md-6">
             <span class="text-muted">Site generated at {{ 'now' | date: "%e %B %Y %H:%M %Z" }}</span><br />
-            <a class="text-muted" href="{{ site.github.url }}/code-of-conduct">Code of Conduct</a>
+            <a class="text-muted" href="{{ site.github.url }}/code-of-conduct">Code of Conduct</a><br />
+            <a class="text-muted" href="{{ site.github.url }}/privacy-policy">Privacy Policy</a>
           </div>
           <div class="col-md-6 ml-auto text-right">
             <a class="text-muted" href="{{ site.github.repository_url }}">Edit on Github</a>

--- a/pages/privacy-policy.md
+++ b/pages/privacy-policy.md
@@ -1,0 +1,58 @@
+---
+layout: post
+title: Privacy Policy
+permalink: /privacy-policy/
+excerpt: Code for IATI's Privacy Policy
+---
+
+This Policy describes the information we collect from you, how we use that information and our legal basis for doing so. It also covers whether and how that information may be shared and your rights and choices regarding the information you provide to us. This Privacy Policy applies to the information that we obtain through your use of Code for IATI websites including its subdomains [datastore.codeforiati.org](https://datastore.codeforiati.org).
+
+### Who we are
+
+Code for IATI is a loose collaborative of [IATI](https://iatistandard.org) community members, developing tools and guidance in support of IATI infrastructure, publishers and data users.
+
+The data processor is Mark Brough, c/o Der Salon, Schudomastr 45, 12055 Berlin.
+
+### What we collect and receive
+
+In order for us to provide you the best possible experience on our websites, we need to collect and process certain information. Depending on your use of the Services, that may include:
+
+* Contact us via email — for example, when you ask for support, send us questions or comments, or report a problem, we will collect your name, email address, message, etc. We use this data solely in connection with answering the queries we receive.
+* Usage data — when you visit our site, we will store: the website from which you visited us from, the parts of our site you visit, the date and duration of your visit, your anonymised IP address, information from the device (device type, operating system, screen resolution, language, country you are located in, and web browser type) you used during your visit, and more. We process this usage data in Matomo Analytics for statistical purposes, to improve our site and to recognize and stop any misuse.
+* Cookies — we use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactivate or restrict the transmission of cookies by changing the settings of your web browser. Cookies that are already stored may be deleted at any time.
+
+### Opt out of website tracking
+
+You can opt out of our website tracking below:
+
+<iframe style="border: 0; height: 200px; width: 600px;" src="https://matomo.codeforiati.org/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=&fontColor=&fontSize=&fontFamily="></iframe>
+
+
+### Your Rights
+
+You have the right to be informed of Personal Data processed by Code for IATI, a right to rectification/correction, erasure and restriction of processing. You also have the right to ask from us a structured, common and machine-readable format of Personal Data you provided to us. We can only identify you via your email address and we can only adhere to your request and provide information if we have Personal Data about you through you having made contact with us directly and/or you using our site and/or service. We cannot provide, rectify or delete any data that we store on behalf of our users or customers. To exercise any of the rights mentioned in this Privacy Policy and/or in the event of questions or comments relating to the use of Personal Data you may contact Code for IATI: [hello@codeforiati.org](mailto:hello@codeforiati.org) In addition, you have the right to lodge a complaint with the data protection authority in your jurisdiction.
+
+### Subprocessors
+
+We use a select number of trusted external service providers for certain technical data processing and/or service offerings. These service providers are carefully selected and meet high data protection and security standards. We only share information with them that is required for the services offered and we contractually bind them to keep any information we share with them as confidential and to process Personal Data only according to our instructions. Code for IATI uses the following subprocessors to process the data collected by our websites:
+
+**Subprocessor**: [Gandi](https://www.gandi.net/)
+**Data location**: Europe, France
+**Service**: Secure infrastructure for servers and databases and logs hosted in Paris, France.
+
+We host our own instance of Matomo Analytics on these services, in order to collect and analyse information about how you interact with our websites (web analytics), and to recognize and stop any misuse. We have a legitimate interest in processing this data.
+
+### Retention of data
+
+We will retain your information as long as your account is active, as necessary to provide you with the services or as otherwise set forth in this Policy. We will also retain and use this information as necessary for the purposes set out in this Policy and to the extent necessary to comply with our legal obligations, resolve disputes, enforce our agreements and protect our legal rights. We also collect and maintain aggregated, anonymized or pseudonymized information which we may retain indefinitely to protect the safety and security of our Site, improve our Services or comply with legal obligations.
+
+#### Privacy Policy Changes
+
+We may update this Policy from time to time. If we do, we’ll let you know about any material changes, by notifying you on this page.
+
+#### Contact Us
+
+E-Mail: [hello@codeforiati.org](mailto:hello@codeforiati.org)
+
+
+This privacy policy is based on the template provided by Matomo at [matomo.org/privacy-policy/](https://matomo.org/privacy-policy/)


### PR DESCRIPTION
Adds a privacy policy for Code for IATI services, for analytics hosted on matomo.codeforiati.org and using the Matomo Privacy Policy