### PR TITLE
Hide some projects

### DIFF
--- a/_projects/01_tech_call.md
+++ b/_projects/01_tech_call.md
@@ -4,6 +4,7 @@ tags:
     - tools
     - users
 link: https://docs.google.com/document/d/1QtChR3JiUCD3USa7UnrMPIZszQ1N8cPCX5LxooODttg/edit
+hidden: true
 ---
 
 A monthly call with 5 minute presentations to share new IATI tech.

--- a/_projects/04_iati_uptime.md
+++ b/_projects/04_iati_uptime.md
@@ -4,6 +4,7 @@ tags:
     - tools
     - users
 link: https://uptime.codeforiati.org
+hidden: true
 ---
 
 Uptime monitoring dashboard for IATI services.

--- a/_projects/055_iati_status.md
+++ b/_projects/055_iati_status.md
@@ -4,6 +4,7 @@ tags:
     - tools
     - users
 link: https://iati-status.codeforiati.org
+hidden: true
 ---
 
 Smoke tests and sanity checks for some live IATI websites and web tools.

--- a/_projects/13_iati_datastore.md
+++ b/_projects/13_iati_datastore.md
@@ -3,6 +3,7 @@ title: IATI Datastore
 tags:
     - tools
 link: https://iatidatastore.iatistandard.org/
+hidden: true
 ---
 
 The IATI Datastore provides data on development and humanitarian spending and projects that address poverty and crises across the world.

--- a/index.html
+++ b/index.html
@@ -27,17 +27,19 @@
     <div class="container">
         <div class="row">
         {% for project in site.projects reversed %}
-        <div class="col-12">
-            <div class="card mb-4 shadow-sm">
-                <div class="card-header">
-                    <h4 class="my-0 font-weight-normal"><a href="{{ project.link }}">{{ project.title }}</a></h4>
-                </div>
-                <div class="card-body">
-                    <p>{{ project.content | remove: '<p>' | remove: '</p>' }}</p>
-                    <p>{% for tag in project.tags %} <span class="badge badge-pill badge-secondary">{{ tag }}</span>{% endfor %}</p>
+            {% unless project.hidden %}
+            <div class="col-12">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
+                        <h4 class="my-0 font-weight-normal"><a href="{{ project.link }}">{{ project.title }}</a></h4>
+                    </div>
+                    <div class="card-body">
+                        <p>{{ project.content | remove: '<p>' | remove: '</p>' }}</p>
+                        <p>{% for tag in project.tags %} <span class="badge badge-pill badge-secondary">{{ tag }}</span>{% endfor %}</p>
+                    </div>
                 </div>
             </div>
-        </div>
+            {% endunless %}
         {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
This hides the following projects:
* Monthly tech call (because we don’t really do this anymore)
* [IATI Uptime](https://uptime.codeforiati.org/) (not really interesting)
* [IATI Status](https://iati-status.codeforiati.org/) (not really interesting, and should maybe switch it off)
* [IATI Datastore](https://iatidatastore.iatistandard.org/) (just links to a holding page)